### PR TITLE
Fixed event name mismatch in Spinner.as

### DIFF
--- a/flexstore4/src/com/grakl/Spinner.as
+++ b/flexstore4/src/com/grakl/Spinner.as
@@ -49,7 +49,7 @@ package com.grakl {
             
             addEventListener(FlexEvent.CREATION_COMPLETE, onSpinnerReady);
 			addEventListener(FlexEvent.SHOW, onShowHideSpinner);
-			addEventListener(FlexEvent.SHOW, onShowHideSpinner);
+			addEventListener(FlexEvent.HIDE, onShowHideSpinner);
         }
         
         


### PR DESCRIPTION
Now, this way, spinner will actually stop on HIDE event.
